### PR TITLE
Update type hint in perplexity/utils.py 

### DIFF
--- a/perplexity/utils.py
+++ b/perplexity/utils.py
@@ -1,4 +1,6 @@
-def return_just_next_token(answer: [dict]) -> str:
+from typing import Iterable, Dict
+
+def return_just_next_token(answer: Iterable[Dict]) -> str:
     length = 0
     for partial_answer in answer:
         yield partial_answer["answer"][length:]

--- a/perplexity/utils.py
+++ b/perplexity/utils.py
@@ -1,4 +1,4 @@
-def return_just_next_token(answer: iter[dict]) -> str:
+def return_just_next_token(answer: [dict]) -> str:
     length = 0
     for partial_answer in answer:
         yield partial_answer["answer"][length:]


### PR DESCRIPTION
When I import perplexityai with the original utils.py,
I got
```
TypeError: 'builtin_function_or_method' object is not subscriptable
```
in utils.py, line 1.
So, instead of using build-in types, I suggest you to use typing library.